### PR TITLE
feat: add TimeInterval primitive

### DIFF
--- a/src/TheTimeLedger.SharedKernel/Primitives/TimeInterval.cs
+++ b/src/TheTimeLedger.SharedKernel/Primitives/TimeInterval.cs
@@ -1,0 +1,7 @@
+namespace TheTimeLedger.SharedKernel.Primitives;
+
+/// <summary>
+/// Pure time interval primitive (no domain semantics).
+/// Consumers define rules such as overlap, inclusivity, rounding, etc.
+/// </summary>
+public sealed record TimeInterval(DateTimeOffset Start, DateTimeOffset End);

--- a/tests/TheTimeLedger.SharedKernel.Tests/Primitives/TimeIntervalTests.cs
+++ b/tests/TheTimeLedger.SharedKernel.Tests/Primitives/TimeIntervalTests.cs
@@ -1,0 +1,18 @@
+using TheTimeLedger.SharedKernel.Primitives;
+
+namespace TheTimeLedger.SharedKernel.Tests.Primitives;
+
+public class TimeIntervalTests
+{
+    [Fact]
+    public void Should_store_start_and_end()
+    {
+        var start = DateTimeOffset.Parse("2025-01-01T10:00:00+00:00");
+        var end = DateTimeOffset.Parse("2025-01-01T11:00:00+00:00");
+
+        var interval = new TimeInterval(start, end);
+
+        Assert.Equal(start, interval.Start);
+        Assert.Equal(end, interval.End);
+    }
+}


### PR DESCRIPTION
## Context

Multiple bounded contexts within TheTimeLedger need to represent a basic time interval
without embedding domain-specific semantics.

Introducing this concept directly in a domain would either cause duplication or
premature coupling across contexts.

## What’s included

- Added `TimeInterval` as a pure primitive to the SharedKernel
- The primitive represents a simple `(Start, End)` pair
- No validation or business logic is included by design

## Rationale

`TimeInterval` is intended to be a stable, universally meaningful building block.
Any domain-specific rules (e.g. overlap, inclusivity, rounding) must live inside
the consuming bounded context.

This keeps the SharedKernel minimal, stable, and free from business semantics.

## Impact

- Backward compatible change
- No breaking changes to existing consumers
- Enables consistent time modeling across bounded contexts
